### PR TITLE
Update redirect URLs to main domain

### DIFF
--- a/nginx/csv-to-nginx-redirects.py
+++ b/nginx/csv-to-nginx-redirects.py
@@ -44,7 +44,7 @@ def main():
                         continue
                     old_path, new_path = row
                     output.write(f"location = {old_path} {{\n")
-                    output.write(f"    return 302 https://new.system-school.ru{new_path};\n")
+                    output.write(f"    return 302 https://system-school.ru{new_path};\n")
                     output.write("}\n\n")
         except FileNotFoundError:
             output.write("# No internal redirects specified\n\n")

--- a/nginx/includes.d/redirects.conf
+++ b/nginx/includes.d/redirects.conf
@@ -6,127 +6,127 @@
 
 # Internal: Pages with new paths on the same site
 location = /intro {
-    return 302 https://new.system-school.ru/programs/intro;
+    return 302 https://system-school.ru/programs/intro;
 }
 
 location = /organizationaldevelopment {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /1-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /2-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /3-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /4-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /5-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /6-org-dev {
-    return 302 https://new.system-school.ru/programs/orgdev;
+    return 302 https://system-school.ru/programs/orgdev;
 }
 
 location = /openendedness {
-    return 302 https://new.system-school.ru/open-endedness;
+    return 302 https://system-school.ru/open-endedness;
 }
 
 location = /qualificationlevels {
-    return 302 https://new.system-school.ru/qualification;
+    return 302 https://system-school.ru/qualification;
 }
 
 location = /howtochooseyourpath {
-    return 302 https://new.system-school.ru/howtostart;
+    return 302 https://system-school.ru/howtostart;
 }
 
 location = /quickpurchase {
-    return 302 https://new.system-school.ru/quick-purchase;
+    return 302 https://system-school.ru/quick-purchase;
 }
 
 location = /subscribe {
-    return 302 https://new.system-school.ru/;
+    return 302 https://system-school.ru/;
 }
 
 location = /tserenov {
-    return 302 https://new.system-school.ru/team/tserenov;
+    return 302 https://system-school.ru/team/tserenov;
 }
 
 location = /levenchuk {
-    return 302 https://new.system-school.ru/team/levenchuk;
+    return 302 https://system-school.ru/team/levenchuk;
 }
 
 location = /klimat {
-    return 302 https://new.system-school.ru/team/klimat;
+    return 302 https://system-school.ru/team/klimat;
 }
 
 location = /mizgulin {
-    return 302 https://new.system-school.ru/team/mizgulin;
+    return 302 https://system-school.ru/team/mizgulin;
 }
 
 location = /paramonova {
-    return 302 https://new.system-school.ru/team/paramonova;
+    return 302 https://system-school.ru/team/paramonova;
 }
 
 location = /medvedeva {
-    return 302 https://new.system-school.ru/team/medvedeva;
+    return 302 https://system-school.ru/team/medvedeva;
 }
 
 location = /agroskin {
-    return 302 https://new.system-school.ru/team/agroskin;
+    return 302 https://system-school.ru/team/agroskin;
 }
 
 location = /lubenchenko {
-    return 302 https://new.system-school.ru/team/lubenchenko;
+    return 302 https://system-school.ru/team/lubenchenko;
 }
 
 location = /oleshko {
-    return 302 https://new.system-school.ru/team/oleshko;
+    return 302 https://system-school.ru/team/oleshko;
 }
 
 location = /ilya {
-    return 302 https://new.system-school.ru/team/zolotarev;
+    return 302 https://system-school.ru/team/zolotarev;
 }
 
 location = /ivan_m {
-    return 302 https://new.system-school.ru/team/metelkin;
+    return 302 https://system-school.ru/team/metelkin;
 }
 
 location = /julia_chaikovskaya {
-    return 302 https://new.system-school.ru/team/chaikovskaya;
+    return 302 https://system-school.ru/team/chaikovskaya;
 }
 
 location = /kunev {
-    return 302 https://new.system-school.ru/team/kunev;
+    return 302 https://system-school.ru/team/kunev;
 }
 
 location = /rukavishnikov {
-    return 302 https://new.system-school.ru/team/rukavishnikov;
+    return 302 https://system-school.ru/team/rukavishnikov;
 }
 
 location = /landikov {
-    return 302 https://new.system-school.ru/team/landikov;
+    return 302 https://system-school.ru/team/landikov;
 }
 
 location = /sergeysoloboev {
-    return 302 https://new.system-school.ru/team/soloboev;
+    return 302 https://system-school.ru/team/soloboev;
 }
 
 location = /turkhanov {
-    return 302 https://new.system-school.ru/team;
+    return 302 https://system-school.ru/team;
 }
 
 location = /bodrov {
-    return 302 https://new.system-school.ru/team;
+    return 302 https://system-school.ru/team;
 }
 
 # External: Pages redirecting to old.system-school


### PR DESCRIPTION
Redirects have been updated to use the main domain instead of the old subdomain, ensuring all links point to the correct location.