### PR TITLE
Add sitemap configuration with hostname

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -7,6 +7,11 @@ export default defineConfig({
     lang: "ru-RU",
     title: "Мастерская инженеров-менеджеров",
     description: "Готовим директоров по развитию, меняющих мир к лучшему",
+    
+    // Sitemap configuration
+    sitemap: {
+        hostname: 'https://system-school.ru'
+    },
 
     themeConfig: {
         siteTitle: "Мастерская инженеров-менеджеров",


### PR DESCRIPTION
Implement sitemap configuration to generate a complete and up-to-date `sitemap.xml` for system-school, ensuring proper hostname is set for the sitemap generation.

Fixes #17