### PR TITLE
Enable clean URLs and update Nginx configuration for SPA support

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -8,6 +8,9 @@ export default defineConfig({
     title: "Мастерская инженеров-менеджеров",
     description: "Готовим директоров по развитию, меняющих мир к лучшему",
     
+    // Clean URLs - removes .html suffixes from URLs
+    cleanUrls: true,
+    
     // Sitemap configuration
     sitemap: {
         hostname: 'https://system-school.ru'

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ This project features automated CI/CD with Docker and Nomad:
 - **Assets**: Images and static files in `src/public/`
 - **Styling**: Custom SCSS with Bootstrap integration
 
-### URL Redirects
-- **Configuration**: Stored in `nginx/includes.d/redirects.conf`, auto-generated from CSV files
+### URL Features
+- **Clean URLs**: Site uses clean URLs without `.html` suffixes (configured in `.vitepress/config.mts`)
+- **Nginx Support**: Configured to serve `/page.html` when `/page` is requested
+- **Redirects Configuration**: Stored in `nginx/includes.d/redirects.conf`, auto-generated from CSV files
 - **CSV Types**:
   - `nginx/internal-redirects.csv`: Old paths to new paths on the new site (`/old-path,/new-path`)
   - `nginx/external-redirects.csv`: Paths to redirect to old.system-school (`/path-not-implemented`)

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,9 +61,9 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self';" always;
 
-        # Handle client-side routing for SPA
+        # Handle client-side routing for SPA and support clean URLs (without .html)
         location / {
-            try_files $uri $uri/ /index.html;
+            try_files $uri $uri.html $uri/ /index.html;
         }
 
         # Cache static assets


### PR DESCRIPTION
Implement clean URLs by removing the .html suffix from URLs and update the Nginx configuration to support client-side routing for single-page applications.

Fixes #38