### PR TITLE
Redirect .html URLs to clean URLs for SPA support

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,9 +61,18 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self';" always;
 
-        # Handle client-side routing for SPA and support clean URLs (without .html)
+        # Redirect .html URLs to clean URLs (avoid duplicate content)
+        location ~ ^/(.+)\.html$ {
+            return 302 /$1;
+        }
+
+        # VitePress clean URLs configuration
+        # First try to find the exact URI
+        # Then try to serve it with .html extension (internally)
+        # Then try URI as a directory with index.html
+        # Finally, fall back to 404
         location / {
-            try_files $uri $uri.html $uri/ /index.html;
+            try_files $uri $uri.html $uri/index.html =404;
         }
 
         # Cache static assets

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,7 +63,7 @@ http {
 
         # Redirect .html URLs to clean URLs (avoid duplicate content)
         location ~ ^/(.+)\.html$ {
-            return 302 /$1;
+            return 302 https://system-school.ru/$1;
         }
 
         # VitePress clean URLs configuration


### PR DESCRIPTION
Enhance single-page application support by redirecting `.html` URLs to their clean counterparts, addressing potential duplicate content issues. This change improves routing and user experience. Fixes #40